### PR TITLE
dispaly outline of selected 3D model

### DIFF
--- a/app/javascript/components/Castle.jsx
+++ b/app/javascript/components/Castle.jsx
@@ -478,11 +478,20 @@ function Castle(props){
     )
   }
 
+  
+
   function useClickModel(model_number){
-    const ref = useRef()
+    const ref = useState(useRef())
+    useEffect(() => {
+      if(model_number==editModelNumber){
+        setEditModelRef([ref.current])
+      }
+    })
     const setEditModelRef = useContext(context)
-    const onClick = () => { setEditModelNumber(model_number), setEditModelRef([ref.current])}
-    return { ref, onClick}
+    const onClick = useCallback(() =>  {setEditModelRef([ref.current])
+       setEditModelNumber(model_number)
+     }, [])
+    return { ref, onClick }
   }
 
 


### PR DESCRIPTION
城のパーツを編集(移動させたり, 回転させたりなど)するとアウトラインの表示が消えてしまう問題を解消した